### PR TITLE
Remove NaN from dataset.

### DIFF
--- a/tread.py
+++ b/tread.py
@@ -50,13 +50,8 @@ def get_tread_dataset(file, grid, start_date, end_date):
 
     tread = tread[list(TREAD_CHANNELS.keys())].rename(TREAD_CHANNELS)
 
-    # Based on CWA grid, regrid TReAD data over spatial dimensions for all timestamps.
+    # Based on REF grid, regrid TReAD data over spatial dimensions for all timestamps.
     tread_out = regrid_dataset(tread, grid)
-
-    # Replace 0 to nan for TReAD domain is smaller than CWB_zarr.
-    fill_value = np.nan
-    tread_out["temperature_2m"] = tread_out["temperature_2m"].where(tread_out["temperature_2m"] != 0, fill_value)
-    tread_out["temperature_2m"].attrs["_FillValue"] = fill_value
 
     return tread, tread_out
 

--- a/util.py
+++ b/util.py
@@ -3,8 +3,10 @@ import xesmf as xe
 import xarray as xr
 
 def regrid_dataset(ds, grid):
-    # Regrid data over the spatial dimensions for all timestamps, based on CWA coordinates.
-    remap = xe.Regridder(ds, grid, method="bilinear", extrap_method=None)
+    # Regrid the dataset to the target grid:
+    # - Use bilinear interpolation to regrid the data.
+    # - Extrapolate by using the nearest valid source cell to extrapolate values for target points outside the source grid.
+    remap = xe.Regridder(ds, grid, method="bilinear", extrap_method="nearest_s2d")
 
     # Regrid each time step while keeping the original coordinates and dimensions
     ds_regrid = xr.concat(


### PR DESCRIPTION
- Extrapolate during regridding.
- Remove redundant code that fill empty point with NaN.

Per CorrDiff paper:
> any missing or corrupted data points represented by "inf" or "nan" values are eliminated from the dataset.